### PR TITLE
Image uploader & distribution using S3 + Cloudflare Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN ruby -e 'puts RUBY_VERSION'
 
 RUN apt-get update && apt-get install -y \
   git \
+  libimage-exiftool-perl \
   libpq-dev \
   patch \
   pkg-config \

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ end
 
 group :development, :test do
   gem "debug"
+  gem "dotenv"
 
   gem "capybara"
   gem "factory_bot_rails"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.1.2"
 
+gem "aws-sdk-s3"
 gem "commonmarker", "~> 0.23"
 gem "haml"
 gem "pg", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.5.0)
     diffy (3.4.2)
+    dotenv (3.0.2)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -322,6 +323,7 @@ DEPENDENCIES
   commonmarker (~> 0.23)
   ddtrace
   debug
+  dotenv
   factory_bot_rails
   haml
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,23 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.893.0)
+    aws-sdk-core (3.191.2)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.77.0)
+      aws-sdk-core (~> 3, >= 3.191.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.143.0)
+      aws-sdk-core (~> 3, >= 3.191.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bigdecimal (3.1.5)
     builder (3.2.4)
@@ -130,6 +147,7 @@ GEM
     irb (1.10.1)
       rdoc
       reline (>= 0.3.8)
+    jmespath (1.6.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     libdatadog (5.0.0.1.0-x86_64-linux)
@@ -299,6 +317,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   capybara
   commonmarker (~> 0.23)
   ddtrace

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+  def require_admin
+    if params[:incunabula_admin_secret] != ENV.fetch('INCUNABULA_ADMIN_SECRET')
+      render plain: "unauthorized", status: :unauthorized
+    end
+  end
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,5 +1,5 @@
 class EntriesController < ApplicationController
-  before_action :require_admin_secret, only: [:create, :update]
+  before_action :require_admin, only: [:create, :update]
 
   def index
     @entries = Entry.all.order(published_at: :desc)
@@ -48,12 +48,6 @@ class EntriesController < ApplicationController
       redirect_to entry_friendly_path(entry_path: @entry.entry_path)
     rescue ActiveRecord::RecordInvalid
       render :edit
-    end
-  end
-
-  private def require_admin_secret
-    if params[:incunabula_admin_secret] != ENV.fetch('INCUNABULA_ADMIN_SECRET')
-      render plain: "unauthorized", status: :unauthorized
     end
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -10,7 +10,9 @@ class ImagesController < ApplicationController
 
   def create
     @image = Image.from_uploaded_file(params[:file])
+    Image.strip_exif!(params[:file].path)
     @image.upload_to_s3(params[:file].read)
+
     ActiveRecord::Base.transaction do
       @image.save!
     end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,0 +1,22 @@
+class ImagesController < ApplicationController
+  before_action :require_admin, only: [:create]
+
+  def show
+    @image = Image.find(params[:id])
+  end
+
+  def new
+  end
+
+  def create
+    @image = Image.from_uploaded_file(params[:file])
+    @image.upload_to_s3(params[:file].read)
+    ActiveRecord::Base.transaction do
+      @image.save!
+    end
+
+    redirect_to image_path(@image)
+  rescue ActiveRecord::RecordInvalid
+    render :new, status: 422
+  end
+end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -3,6 +3,12 @@ class ImagesController < ApplicationController
 
   def show
     @image = Image.find(params[:id])
+    @embed_tag = <<~__EOS__
+    <div style="font-size: 14px; text-align: center;">
+    <a href="#{@image.public_url}"><img src="#{@image.public_url(width: 480)}" style="max-width: min(480px, 90%); border: 1px solid #000;" /></a><br />
+    (caption)
+    </div>
+    __EOS__
   end
 
   def new

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,2 @@
+class Image < ApplicationRecord
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,2 +1,44 @@
 class Image < ApplicationRecord
+  S3_BUCKET = Rails.configuration.x.image_distribution[:s3_bucket]
+  S3_PREFIX = Rails.configuration.x.image_distribution[:s3_prefix]
+
+  validates :original_filename, presence: true
+  validates :content_type, presence: true
+  validates :s3_key, presence: true
+
+  # @param file [ActionDispatch::Http::UploadedFile]
+  def self.from_uploaded_file(file)
+    new(
+      original_filename: file.original_filename,
+      content_type: file.content_type,
+    )
+  end
+
+  def public_url
+    # TODO: Replace with Cloudflare Images
+    "https://#{S3_BUCKET}.s3.ap-northeast-1.amazonaws.com/#{self.s3_key}"
+  end
+
+  # Assign a new S3 key and upload the blob.
+  # @param blob [String]
+  def upload_to_s3(blob)
+    filename = self.generate_filename
+    self.s3_key = "#{S3_PREFIX}/img/original/#{filename}"
+
+    s3 = Aws::S3::Client.new
+    s3.put_object(
+      bucket: S3_BUCKET,
+      key: self.s3_key,
+      body: blob,
+      content_type: self.content_type,
+    )
+  end
+
+  def generate_filename
+    timestamp = Time.current.strftime('%Y%m%d%H%M%S')
+    random = SecureRandom.hex(6)
+    extension = File.extname(original_filename)
+
+    "#{timestamp}_#{random}#{extension}"
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -15,7 +15,7 @@ class Image < ApplicationRecord
   end
 
   def self.strip_exif!(path)
-    system('exiftool', '-overwrite_original_in_place', '-EXIF=', path, exception: true)
+    system('exiftool', '-overwrite_original_in_place', '-gps*=', path, exception: true)
   end
 
   def public_url

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -18,9 +18,13 @@ class Image < ApplicationRecord
     system('exiftool', '-overwrite_original_in_place', '-gps*=', path, exception: true)
   end
 
-  def public_url
-    # TODO: Replace with Cloudflare Images
-    "https://#{S3_BUCKET}.s3.ap-northeast-1.amazonaws.com/#{self.s3_key}"
+  def public_url(resize_options = nil)
+    if resize_options
+      options_str = resize_options.map { |k, v| "#{k}=#{v}" }.join(',')
+      "https://#{Rails.configuration.x.image_distribution[:public_url_host]}/cdn-cgi/image/#{options_str}/#{self.s3_key}"
+    else
+      "https://#{Rails.configuration.x.image_distribution[:public_url_host]}/#{self.s3_key}"
+    end
   end
 
   # Assign a new S3 key and upload the blob.

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -14,6 +14,10 @@ class Image < ApplicationRecord
     )
   end
 
+  def self.strip_exif!(path)
+    system('exiftool', '-overwrite_original_in_place', '-EXIF=', path, exception: true)
+  end
+
   def public_url
     # TODO: Replace with Cloudflare Images
     "https://#{S3_BUCKET}.s3.ap-northeast-1.amazonaws.com/#{self.s3_key}"

--- a/app/views/images/new.html.haml
+++ b/app/views/images/new.html.haml
@@ -1,0 +1,9 @@
+= form_with(url: images_path, method: :post, local: true) do |f|
+  %div
+    = f.file_field :file
+  %div
+    = f.label :secret, "Secret"
+    %br
+    = text_field_tag :incunabula_admin_secret
+  %div
+    = f.submit

--- a/app/views/images/show.html.haml
+++ b/app/views/images/show.html.haml
@@ -4,4 +4,8 @@
 Public URL
 = text_field_tag nil, @image.public_url, size: 80, disabled: true
 %br
-= image_tag @image.public_url
+Embed tag
+%br
+= text_area_tag nil, @embed_tag, rows: 5, cols: 100, wrap: 'off'
+%br
+= image_tag @image.public_url, style: "width: 100%;"

--- a/app/views/images/show.html.haml
+++ b/app/views/images/show.html.haml
@@ -1,0 +1,7 @@
+%h2 Image
+= @image.created_at
+%br
+Public URL
+= text_field_tag nil, @image.public_url, size: 80, disabled: true
+%br
+= image_tag @image.public_url

--- a/config/initializers/image_distribution.rb
+++ b/config/initializers/image_distribution.rb
@@ -1,0 +1,4 @@
+Rails.configuration.x.image_distribution = {
+  s3_bucket: ENV.fetch('INCN_IMAGE_DISTRIBUTION_S3_BUCKET'),
+  s3_prefix: ENV.fetch('INCN_IMAGE_DISTRIBUTION_S3_PREFIX'),
+}

--- a/config/initializers/image_distribution.rb
+++ b/config/initializers/image_distribution.rb
@@ -1,4 +1,5 @@
 Rails.configuration.x.image_distribution = {
   s3_bucket: ENV.fetch('INCN_IMAGE_DISTRIBUTION_S3_BUCKET'),
   s3_prefix: ENV.fetch('INCN_IMAGE_DISTRIBUTION_S3_PREFIX'),
+  public_url_host: ENV.fetch('INCN_IMAGE_DISTRIBUTION_PUBLIC_URL_HOST'),
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     root to: 'entries#index'
     resources :entries, only: [:new, :create, :update]
     resources :feed, only: [:index]
+    resources :images, only: [:show, :new, :create]
 
     # Give lowest precendence
     get '/*entry_path', to: 'entries#show', as: 'entry_friendly', constraints: { entry_path: %r|\d{4}/\d{2}/\d{2}/\d{6}| }

--- a/db/schemata/images.schema
+++ b/db/schemata/images.schema
@@ -1,0 +1,8 @@
+create_table :images do |t|
+  t.string :original_filename, null: false
+  t.string :content_type, null: false
+  t.string :s3_key, null: false
+  t.timestamps
+end
+
+# vim: set ft=ruby :

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :image do
+    original_filename { 'IMG_1234.jpg' }
+    content_type { 'image/jpeg' }
+    s3_key { '20240606100000_3e2c80620c79.jpg' }
+  end
+end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Image, type: :model do
+  describe '#public_url' do
+    context 'when resize_options is specified' do
+      it do
+        image = Image.new(
+          original_filename: 'IMG_1234.jpg',
+          content_type: 'image/jpeg',
+          s3_key: '20240606095000_25e616570eb9.jpg'
+        )
+
+        expect(image.public_url({ width: 480 })).to eq('https://static.osyoyu.com/cdn-cgi/image/width=480/20240606095000_25e616570eb9.jpg')
+      end
+    end
+
+    context 'when resize_options is not specified' do
+      it do
+        image = Image.new(
+          original_filename: 'IMG_1234.jpg',
+          content_type: 'image/jpeg',
+          s3_key: '20240606095000_25e616570eb9.jpg'
+        )
+
+        expect(image.public_url).to eq('https://static.osyoyu.com/20240606095000_25e616570eb9.jpg')
+      end
+    end
+  end
+end

--- a/spec/system/images_spec.rb
+++ b/spec/system/images_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Images', type: :system do
+  before do
+    driven_by :rack_test
+  end
+
+  describe '/blog/images/new' do
+    context 'happy path' do
+      it 'responds with 200' do
+        visit '/blog/images/new'
+        expect(page).to have_http_status(200)
+      end
+    end
+  end
+
+  describe '/blog/images/:id' do
+    context 'happy path' do
+      let!(:image) { create(:image) }
+
+      it 'responds with 200' do
+        visit "/blog/images/#{image.id}"
+        expect(page).to have_http_status(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implemented a image management feature. The uploaded file is stored at S3, then distributed through Cloudflare Images. EXIF tags are preserved with the exception of geo data.

Todos:

- Support for an easy syntax like `[incn:image:6]`
- Keep EXIF data in the DB instead of the file?