### PR TITLE
ImportSource: A place to record original metadata of imported entries

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,5 +1,6 @@
 class Entry < ApplicationRecord
   has_many :embed_links, dependent: :destroy
+  has_one :import_source, dependent: :destroy
 
   scope :published, -> { where(is_draft: false) }
   scope :diary, -> { where(title: nil) }

--- a/app/models/import_source.rb
+++ b/app/models/import_source.rb
@@ -1,0 +1,3 @@
+class ImportSource < ApplicationRecord
+  belongs_to :entry
+end

--- a/app/views/entries/show.html.haml
+++ b/app/views/entries/show.html.haml
@@ -21,8 +21,13 @@
 %article
   %header.article-header
     %h1= link_to @entry.display_title, entry_friendly_path(entry_path: @entry.entry_path)
-    - if !@entry.title.nil?
+    - if @entry.title != nil
       .date= @entry.published_at_formatted
+
+    - if @entry.import_source != nil
+      .import_source
+        Original:
+        = @entry.import_source.original_url
 
   %hr.header-main-divider
 

--- a/app/views/entries/show.html.haml
+++ b/app/views/entries/show.html.haml
@@ -1,4 +1,7 @@
 - content_for :head do
+  - if @entry.import_source != nil
+    %link{rel: 'canonical', href: @entry.import_source.original_url}
+
   %script{src: "https://b.st-hatena.com/js/bookmark_button.js", async: "async"}
   %script{src: "https://s.hatena.ne.jp/js/HatenaStar.js", defer: "defer"}
   :javascript

--- a/db/schemata/import_sources.schema
+++ b/db/schemata/import_sources.schema
@@ -1,0 +1,8 @@
+create_table :import_sources do |t|
+  t.references :entry, foreign_key: true
+  t.string :era
+  t.string :original_url
+  t.timestamps
+end
+
+# vim: set ft=ruby :

--- a/public/blog-style.css
+++ b/public/blog-style.css
@@ -114,6 +114,11 @@ article header a:hover {
   transition: text-decoration 0.3s;
 }
 
+article header .import_source {
+  color: #666;
+  font-size: 0.9em;
+}
+
 article hr.header-main-divider {
   margin: 1.2em auto 1.2em 0;
   max-width: min(300px, 40%);


### PR DESCRIPTION
This patch adds the `ImportSource` model which represents the _original_ metadata of imported entries. Current fields are:

- era: Which _era_ the entry came from
- original_url: The original URL which the entry came from. Used for `<link rel="canonical" />`.

References:

- [How to Specify a Canonical with rel="canonical" and Other Methods | Google Search Central](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls?hl=en)
- [はてなブックマークにおける正規化URLの扱い | Hatena Developer Center](https://developer.hatena.ne.jp/ja/documents/bookmark/misc/canonical_url/)