### PR TITLE
Introduce Entry#visibility in place of is_draft

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -2,11 +2,11 @@ class EntriesController < ApplicationController
   before_action :require_admin, only: [:create, :update]
 
   def index
-    @entries_by_year = Entry.published.order(published_at: :desc).group_by {|e| e.published_at.year }
+    @entries_by_year = Entry.listable.order(published_at: :desc).group_by {|e| e.published_at.year }
   end
 
   def show
-    @entry = Entry.includes(:embed_links).published.find_by!(entry_path: params[:entry_path])
+    @entry = Entry.includes(:embed_links).find_by!(entry_path: params[:entry_path])
     @body_html = @entry.render_to_html
   end
 
@@ -27,7 +27,7 @@ class EntriesController < ApplicationController
       body: params[:entry][:body],
       published_at:,
       entry_path:,
-      is_draft: params[:entry][:is_draft],
+      visibility: params[:entry][:visibility],
     )
 
     ActiveRecord::Base.transaction do
@@ -41,7 +41,7 @@ class EntriesController < ApplicationController
   end
 
   def update
-    entry_params = params.require(:entry).permit(:title, :body, :is_draft)
+    entry_params = params.require(:entry).permit(:title, :body, :visibility)
 
     @entry = Entry.find(params[:id])
     @entry.assign_attributes(entry_params)

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,6 +1,6 @@
 class FeedController < ApplicationController
   def index
-    entries = Entry.all.order(published_at: :desc).limit(10)
+    entries = Entry.listable.order(published_at: :desc).limit(10)
     feed = RSS::Maker.make('atom') do |maker|
       maker.channel.id = "tag:osyoyu.com,2023:blog"
       maker.channel.title = "osyoyu.com/blog"

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -2,9 +2,11 @@ class Entry < ApplicationRecord
   has_many :embed_links, dependent: :destroy
   has_one :import_source, dependent: :destroy
 
-  scope :published, -> { where(is_draft: false) }
+  scope :listable, -> { where(visibility: "public") }
   scope :diary, -> { where(title: nil) }
   scope :not_diary, -> { where.not(title: nil) }
+
+  enum visibility: { public: "public", unlisted: "unlisted" }, _prefix: true  # no private state now
 
   def display_title
     title.nil? ? published_at_formatted : title

--- a/app/views/entries/_form.html.haml
+++ b/app/views/entries/_form.html.haml
@@ -6,8 +6,10 @@
   %div
     = f.text_area :body
   %div
-    = f.check_box :is_draft
-    draft?
+    = f.radio_button :visibility, "public"
+    public
+    = f.radio_button :visibility, "unlisted"
+    unlisted
   %div
     = f.label :secret, "Secret"
     %br

--- a/db/schemata/entries.schema
+++ b/db/schemata/entries.schema
@@ -4,7 +4,7 @@ create_table :entries do |t|
   t.text :prerendered_body
   t.datetime :published_at, null: false, precision: 0
   t.string :entry_path, null: false
-  t.boolean :is_draft, default: false
+  t.string :visibility, default: "public"
   t.timestamps
 
   t.index :published_at

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     sequence(:title) { |n| "Entry #{n}" }
     sequence(:body) { "The quick brown fox jumps over the lazy dog" }
     published_at { Time.current }
-    is_draft { false }
+    visibility { "public" }
   end
 end

--- a/spec/models/entry/scope_spec.rb
+++ b/spec/models/entry/scope_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Entry, type: :model do
-  describe '.public' do
-    it 'excludes drafts' do
-      entry1 = create(:entry, entry_path: '123', is_draft: false)
-      entry2 = create(:entry, entry_path: '123', is_draft: true)
-      expect(Entry.published.count).to eq(1)
-      expect(Entry.published.first.id).to eq(entry1.id)
+  describe '.listable' do
+    it 'excludes unlisted' do
+      entry1 = create(:entry, entry_path: '123', visibility: "public")
+      entry2 = create(:entry, entry_path: '123', visibility: "unlisted")
+      expect(Entry.listable.count).to eq(1)
+      expect(Entry.listable.first.id).to eq(entry1.id)
     end
   end
 end

--- a/spec/system/entries_spec.rb
+++ b/spec/system/entries_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe 'Entries', type: :system do
       end
     end
 
-    context 'when draft entries exist' do
+    context 'when unlisted entries exist' do
       let!(:published) {
-        create(:entry, title: 'Published', entry_path: '2024/06/15/020000')
+        create(:entry, title: 'Published', entry_path: '2024/06/15/020000', visibility: "public")
       }
-      let!(:draft) {
-        create(:entry, title: 'Very draft', entry_path: '2024/06/15/030000', is_draft: true)
+      let!(:unlisted) {
+        create(:entry, title: 'Very draft', entry_path: '2024/06/15/030000', visibility: "unlisted")
       }
 
       it 'does not show them' do
@@ -39,14 +39,14 @@ RSpec.describe 'Entries', type: :system do
       end
     end
 
-    context 'when entry is a draft' do
-      let!(:draft) {
-        create(:entry, title: 'Very draft', entry_path: '2024/06/15/030000', is_draft: true)
+    context 'even if entry is unlisted' do
+      let!(:unlisted) {
+        create(:entry, title: 'Very draft', entry_path: '2024/06/15/030000', visibility: "unlisted")
       }
 
-      it 'does not show them' do
+      it 'shows it' do
         visit '/blog/2024/06/15/030000'
-        expect(page).to have_http_status(404)
+        expect(page).to have_http_status(200)
       end
     end
   end


### PR DESCRIPTION
Entry#is_draft was introduced in fba556d8068a48da2725f9826809a3210ab16b88, but it wasn't necessarily the best idea.

This patch replaces is_draft with Entry#visibility, which intends to be more generic. Plus, the idea of unlisted entries removes the need of authentication for previewing.